### PR TITLE
AUTH-8 # bumped @blinkmobile/bm-identity to 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,7 @@
 # Change Log
+
+## Next
+
+### Changed
+
+- AUTH-8: bumped `@blinkmobile/bm-identity` to 2.1.0

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "blinkm-identity": "./bin/index.js"
   },
   "dependencies": {
-    "@blinkmobile/bm-identity": "2.0.0",
+    "@blinkmobile/bm-identity": "2.1.0",
     "meow": "^3.7.0",
     "update-notifier": "^1.0.2"
   },


### PR DESCRIPTION
### Changed
- AUTH-8: bumped `@blinkmobile/bm-identity` to 2.1.0
